### PR TITLE
feat: implement a primitive retry for an auth error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,29 +13,29 @@ builds:
     goos:
       - linux
       - darwin
-dockers:
-  # You can have multiple Docker images.
-  -
-    goos: linux
-    goarch: amd64
-
-#    image_templates:
-#      - "myuser/myimage:latest"
-#      - "myuser/myimage:{{ .Tag }}"
-#      - "myuser/myimage:{{ .Tag }}-{{ .Env.GO_VERSION }}"
-#      - "myuser/myimage:v{{ .Major }}"
-#      - "gcr.io/myuser/myimage:latest"
-
-    skip_push: true
-    dockerfile: Dockerfile
-    use: docker
-
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--platform=linux/arm64"
+#dockers:
+#  # You can have multiple Docker images.
+#  -
+#    goos: linux
+#    goarch: amd64
+#
+##    image_templates:
+##      - "myuser/myimage:latest"
+##      - "myuser/myimage:{{ .Tag }}"
+##      - "myuser/myimage:{{ .Tag }}-{{ .Env.GO_VERSION }}"
+##      - "myuser/myimage:v{{ .Major }}"
+##      - "gcr.io/myuser/myimage:latest"
+#
+#    skip_push: true
+#    dockerfile: Dockerfile
+#    use: docker
+#
+#    build_flag_templates:
+#      - "--label=org.opencontainers.image.created={{.Date}}"
+#      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#      - "--label=org.opencontainers.image.version={{.Version}}"
+#      - "--platform=linux/arm64"
 archives:
   - replacements:
       darwin: Darwin

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 	github.com/google/martian v2.1.0+incompatible
-	github.com/gsdevme/unifi v0.0.0-20210728081206-f4e71a3f6b25
+	github.com/gsdevme/unifi v0.0.0-20210731004300-e8e626e36489
 )

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/gsdevme/unifi v0.0.0-20210728081206-f4e71a3f6b25 h1:pXAQETAcfoOwaGMWhLHmfmirqO+JTkBKMqMdc4mtODA=
-github.com/gsdevme/unifi v0.0.0-20210728081206-f4e71a3f6b25/go.mod h1:fHPKYFolFBbJpKY0v+mpTGPalSsIMzCZKPXaQw10xUQ=
+github.com/gsdevme/unifi v0.0.0-20210731004300-e8e626e36489 h1:AbAWTEa7JI7fe4WFHKzFmC6cTmNER5QSnNo7MiPWslc=
+github.com/gsdevme/unifi v0.0.0-20210731004300-e8e626e36489/go.mod h1:fHPKYFolFBbJpKY0v+mpTGPalSsIMzCZKPXaQw10xUQ=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
It seems the Auth token will just randomly expire, upon HttpAuthError having confirmed the user/pass is already known to be good just re authenticate and repeat. Bit terrible like this, must be a more elegant way in golang to do this